### PR TITLE
Fix int to long conversion errors

### DIFF
--- a/Source By Mr Blue/src/nro/models/Bot/BotAttackplayer.java
+++ b/Source By Mr Blue/src/nro/models/Bot/BotAttackplayer.java
@@ -224,7 +224,7 @@ public class BotAttackplayer extends Bot {
 
         int damePST = (int) (dame * percentPST / 100L);
         if (damePST >= attacker.nPoint.hp) {
-            damePST = attacker.nPoint.hp - 1;
+            damePST = (int) (attacker.nPoint.hp - 1);
         }
 
         Message msg = null;
@@ -232,7 +232,7 @@ public class BotAttackplayer extends Bot {
             msg = new Message(56);
             msg.writer().writeInt((int) attacker.id);
             damePST = attacker.injured(attacker, damePST, true, false);
-            msg.writer().writeInt(attacker.nPoint.hp);
+            msg.writer().writeInt((int) attacker.nPoint.hp);
             msg.writer().writeInt(damePST);
             msg.writer().writeBoolean(false);
             msg.writer().writeByte(36);

--- a/Source By Mr Blue/src/nro/models/boss/Boss_mini/Odo.java
+++ b/Source By Mr Blue/src/nro/models/boss/Boss_mini/Odo.java
@@ -88,7 +88,7 @@ public class Odo extends Boss {
                             && Util.getDistance(this, pl) <= 200) {
                         int subHp = (int) ((long) pl.nPoint.hpMax * param / 100);
                         if (subHp >= pl.nPoint.hp) {
-                            subHp = pl.nPoint.hp - 1;
+                            subHp = (int) (pl.nPoint.hp - 1);
                         }
                         this.chat("Bùm Bùm");
                         Service.gI().chat(pl, textOdo[Util.nextInt(0, textOdo.length - 1)]);
@@ -107,7 +107,7 @@ public class Odo extends Boss {
         try {
             if (Util.canDoWithTime(lastTimeHpRegen, 30000)) {
                 int regenPercentage = Util.nextInt(10, 20);
-                int regenAmount = (this.nPoint.hpMax * regenPercentage / 100);
+                int regenAmount = (int) (this.nPoint.hpMax * regenPercentage / 100);
                 PlayerService.gI().hoiPhuc(this, regenAmount, 0);
                 this.chat("Mùi Của Các Ngươi Thơm Quá!! HAHA");
                 this.lastTimeHpRegen = System.currentTimeMillis();

--- a/Source By Mr Blue/src/nro/models/boss/Broly/Broly.java
+++ b/Source By Mr Blue/src/nro/models/boss/Broly/Broly.java
@@ -178,7 +178,7 @@ public class Broly extends Boss {
     }
 
     private void tangChiSo() {
-        int hpMax = this.nPoint.hpMax;
+        long hpMax = this.nPoint.hpMax;
         int rand = Util.nextInt(10, 100);
         hpMax = hpMax + hpMax / rand < 16_070_777 ? hpMax + hpMax / rand : 16_070_777;
         this.nPoint.hpMax = hpMax;

--- a/Source By Mr Blue/src/nro/models/boss/Broly/SuperBroly.java
+++ b/Source By Mr Blue/src/nro/models/boss/Broly/SuperBroly.java
@@ -158,7 +158,7 @@ public class SuperBroly extends Boss {
     }
 
     private void tangChiSo() {
-        int hpMax = this.nPoint.hpMax;
+        long hpMax = this.nPoint.hpMax;
         int rand = Util.nextInt(80, 100);
         hpMax = hpMax + hpMax / rand < 16_070_777 ? hpMax + hpMax / rand : 16_070_777;
         this.nPoint.hpMax = hpMax;

--- a/Source By Mr Blue/src/nro/models/boss/doanh_trai/NinjaAoTim.java
+++ b/Source By Mr Blue/src/nro/models/boss/doanh_trai/NinjaAoTim.java
@@ -121,13 +121,13 @@ public class NinjaAoTim extends Boss {
             if (this.nPoint.hp <= this.nPoint.hpMax / 2 && !this.calledNinja) {
                 if (Util.isTrue(4, 5)) {
                     try {
-                        clan.doanhTrai.bosses.add(new NinjaClone(this.zone, this, this.nPoint.dame / 10, this.nPoint.hpMax / 10, BossID.NINJA_AO_TIM1));
-                        clan.doanhTrai.bosses.add(new NinjaClone(this.zone, this, this.nPoint.dame / 10, this.nPoint.hpMax / 10, BossID.NINJA_AO_TIM2));
-                        clan.doanhTrai.bosses.add(new NinjaClone(this.zone, this, this.nPoint.dame / 10, this.nPoint.hpMax / 10, BossID.NINJA_AO_TIM3));
-                        clan.doanhTrai.bosses.add(new NinjaClone(this.zone, this, this.nPoint.dame / 10, this.nPoint.hpMax / 10, BossID.NINJA_AO_TIM4));
+                        clan.doanhTrai.bosses.add(new NinjaClone(this.zone, this, (int) (this.nPoint.dame / 10), (int) (this.nPoint.hpMax / 10), BossID.NINJA_AO_TIM1));
+                        clan.doanhTrai.bosses.add(new NinjaClone(this.zone, this, (int) (this.nPoint.dame / 10), (int) (this.nPoint.hpMax / 10), BossID.NINJA_AO_TIM2));
+                        clan.doanhTrai.bosses.add(new NinjaClone(this.zone, this, (int) (this.nPoint.dame / 10), (int) (this.nPoint.hpMax / 10), BossID.NINJA_AO_TIM3));
+                        clan.doanhTrai.bosses.add(new NinjaClone(this.zone, this, (int) (this.nPoint.dame / 10), (int) (this.nPoint.hpMax / 10), BossID.NINJA_AO_TIM4));
                         if (Util.isTrue(1, 2)) {
-                            clan.doanhTrai.bosses.add(new NinjaClone(this.zone, this, this.nPoint.dame / 10, this.nPoint.hpMax / 10, BossID.NINJA_AO_TIM5));
-                            clan.doanhTrai.bosses.add(new NinjaClone(this.zone, this, this.nPoint.dame / 10, this.nPoint.hpMax / 10, BossID.NINJA_AO_TIM6));
+                            clan.doanhTrai.bosses.add(new NinjaClone(this.zone, this, (int) (this.nPoint.dame / 10), (int) (this.nPoint.hpMax / 10), BossID.NINJA_AO_TIM5));
+                            clan.doanhTrai.bosses.add(new NinjaClone(this.zone, this, (int) (this.nPoint.dame / 10), (int) (this.nPoint.hpMax / 10), BossID.NINJA_AO_TIM6));
                         }
                     } catch (Exception ex) {
                     }

--- a/Source By Mr Blue/src/nro/models/boss/sieu_hang/Rival.java
+++ b/Source By Mr Blue/src/nro/models/boss/sieu_hang/Rival.java
@@ -37,8 +37,8 @@ public class Rival extends SuperRank {
                 player.name,
                 player.gender,
                 new short[]{player.getHead(), player.getBody(), player.getLeg(), player.getFlagBag(), player.getAura(), player.getEffFront()},
-                player.nPoint.dameg,
-                new int[]{player.nPoint.hpg},
+                (int) player.nPoint.dameg,
+                new int[]{(int) player.nPoint.hpg},
                 new int[]{113},
                 skillTemp,
                 new String[]{}, //text chat 1

--- a/Source By Mr Blue/src/nro/models/boss/vo_dai_hat_mit/Dracula.java
+++ b/Source By Mr Blue/src/nro/models/boss/vo_dai_hat_mit/Dracula.java
@@ -25,7 +25,7 @@ public class Dracula extends DeathOrAliveArena {
     public void hutMau() {
         try {
             if (Util.canDoWithTime(lastTimeHutMau, 15000) && this.nPoint.hp > this.nPoint.hpMax / 30) {
-                int hp = playerAtt.nPoint.hpMax / 10;
+                int hp = (int) (playerAtt.nPoint.hpMax / 10);
                 playerAtt.nPoint.subHP(hp);
                 this.nPoint.addHp(hp);
                 Service.gI().Send_Info_NV(this);

--- a/Source By Mr Blue/src/nro/models/map/Zone.java
+++ b/Source By Mr Blue/src/nro/models/map/Zone.java
@@ -555,8 +555,8 @@ public class Zone {
             msg.writer().writeByte(plInfo.gender);
             msg.writer().writeShort(plInfo.getHead());
             msg.writer().writeUTF(Service.gI().name(plInfo));
-            msg.writer().writeInt(plInfo.nPoint.hp);
-            msg.writer().writeInt(plInfo.nPoint.hpMax);
+            msg.writer().writeInt((int) plInfo.nPoint.hp);
+            msg.writer().writeInt((int) plInfo.nPoint.hpMax);
             msg.writer().writeShort(plInfo.getBody());
             msg.writer().writeShort(plInfo.getLeg());
             int flagbag = plInfo.getFlagBag();

--- a/Source By Mr Blue/src/nro/models/mob/Mob.java
+++ b/Source By Mr Blue/src/nro/models/mob/Mob.java
@@ -458,7 +458,7 @@ public class Mob {
             msg = new Message(-10);
             msg.writer().writeByte(this.id);
             msg.writer().writeInt((int) player.id);
-            msg.writer().writeInt(player.nPoint.hp);
+            msg.writer().writeInt((int) player.nPoint.hp);
             Service.gI().sendMessAnotherNotMeInMap(player, msg);
             msg.cleanup();
         } catch (Exception e) {

--- a/Source By Mr Blue/src/nro/models/mob/MobMe.java
+++ b/Source By Mr Blue/src/nro/models/mob/MobMe.java
@@ -47,7 +47,7 @@ public final class MobMe extends Mob {
                     msg.writer().writeInt(this.id);
                     msg.writer().writeInt((int) pl.id);
                     msg.writer().writeInt(dameHit);
-                    msg.writer().writeInt(pl.nPoint.hp);
+                    msg.writer().writeInt((int) pl.nPoint.hp);
                     Service.gI().sendMessAllPlayerInMap(this.player, msg);
                     msg.cleanup();
                 }

--- a/Source By Mr Blue/src/nro/models/player/EffectSkin.java
+++ b/Source By Mr Blue/src/nro/models/player/EffectSkin.java
@@ -184,10 +184,10 @@ public class EffectSkin {
                             int subHp = (int) ((long) pl.nPoint.hpMax * param / 100);
                             int subMp = (int) ((long) pl.nPoint.mpMax * param / 100);
                             if (subHp >= pl.nPoint.hp) {
-                                subHp = pl.nPoint.hp - 1;
+                                subHp = (int) (pl.nPoint.hp - 1);
                             }
                             if (subMp >= pl.nPoint.mp) {
-                                subMp = pl.nPoint.mp - 1;
+                                subMp = (int) (pl.nPoint.mp - 1);
                             }
                             hpHut += subHp;
                             mpHut += subMp;
@@ -221,7 +221,7 @@ public class EffectSkin {
                                     && Util.getDistance(this.player, pl) <= 200) {
                                 int subHp = (int) ((long) pl.nPoint.hpMax * param / 100);
                                 if (subHp >= pl.nPoint.hp) {
-                                    subHp = pl.nPoint.hp - 1;
+                                    subHp = (int) (pl.nPoint.hp - 1);
                                 }
                                 Service.gI().chat(pl, textOdo[Util.nextInt(0, textOdo.length - 1)]);
                                 PlayerService.gI().sendInfoHpMpMoney(pl);
@@ -410,7 +410,7 @@ public class EffectSkin {
                     double param = this.player.effectSkill.playerUseMafuba.playerSkill.getSkillbyId(Skill.MA_PHONG_BA).point * (this.player.effectSkill.typeBinh == 0 ? 1 : 2);
                     int subHp = (int) ((long) this.player.effectSkill.playerUseMafuba.nPoint.hpMax * param / 100);
                     if (subHp >= this.player.nPoint.hp) {
-                        subHp = Math.abs(this.player.nPoint.hp - 100);
+                        subHp = (int) Math.abs(this.player.nPoint.hp - 100);
                     }
                     PlayerService.gI().sendInfoHpMpMoney(this.player);
                     Service.gI().Send_Info_NV(this.player);

--- a/Source By Mr Blue/src/nro/models/services/PlayerService.java
+++ b/Source By Mr Blue/src/nro/models/services/PlayerService.java
@@ -223,7 +223,7 @@ public class PlayerService {
             }
 
             if (player.isFly && player.getMount() == -1) {
-                int mp = player.nPoint.mpg / (100 * (player.effectSkill.isMonkey ? 2 : 1));
+                int mp = (int) (player.nPoint.mpg / (100 * (player.effectSkill.isMonkey ? 2 : 1)));
                 hoiPhuc(player, 0, -mp);
             }
         }

--- a/Source By Mr Blue/src/nro/models/services/Service.java
+++ b/Source By Mr Blue/src/nro/models/services/Service.java
@@ -596,9 +596,9 @@ public class Service {
         try {
             msg = Service.gI().messageSubCommand((byte) 14);//Cập nhật máu
             msg.writer().writeInt((int) pl.id);
-            msg.writer().writeInt(pl.nPoint.hp);
+            msg.writer().writeInt((int) pl.nPoint.hp);
             msg.writer().writeByte(0);//Hiệu ứng Ăn Đậu
-            msg.writer().writeInt(pl.nPoint.hpMax);
+            msg.writer().writeInt((int) pl.nPoint.hpMax);
             sendMessAnotherNotMeInMap(pl, msg);
             msg.cleanup();
         } catch (Exception e) {
@@ -612,9 +612,9 @@ public class Service {
         try {
             msg = Service.gI().messageSubCommand((byte) 14);//Cập nhật máu
             msg.writer().writeInt((int) pl.id);
-            msg.writer().writeInt(pl.nPoint.hp);
+            msg.writer().writeInt((int) pl.nPoint.hp);
             msg.writer().writeByte(2);
-            msg.writer().writeInt(pl.nPoint.hpMax);
+            msg.writer().writeInt((int) pl.nPoint.hpMax);
             sendMessAnotherNotMeInMap(pl, msg);
             msg.cleanup();
         } catch (Exception e) {
@@ -628,9 +628,9 @@ public class Service {
         try {
             msg = Service.gI().messageSubCommand((byte) 14);
             msg.writer().writeInt((int) pl.id);
-            msg.writer().writeInt(pl.nPoint.hp);
+            msg.writer().writeInt((int) pl.nPoint.hp);
             msg.writer().writeByte(1);
-            msg.writer().writeInt(pl.nPoint.hpMax);
+            msg.writer().writeInt((int) pl.nPoint.hpMax);
             sendMessAnotherNotMeInMap(pl, msg);
             msg.cleanup();
         } catch (Exception e) {
@@ -644,8 +644,8 @@ public class Service {
         try {
             msg = messageSubCommand((byte) 9);
             msg.writer().writeInt((int) pl.id);
-            msg.writer().writeInt(pl.nPoint.hp);
-            msg.writer().writeInt(pl.nPoint.hpMax);
+            msg.writer().writeInt((int) pl.nPoint.hp);
+            msg.writer().writeInt((int) pl.nPoint.hpMax);
             sendMessAnotherNotMeInMap(pl, msg);
         } catch (Exception e) {
             e.printStackTrace();
@@ -794,7 +794,7 @@ public class Service {
                 msg.writer().writeByte(player.nPoint.crit);
                 msg.writer().writeLong(player.nPoint.tiemNang);
                 msg.writer().writeShort(100);
-                msg.writer().writeShort(player.nPoint.defg);
+                msg.writer().writeShort((short) player.nPoint.defg);
                 msg.writer().writeByte(player.nPoint.critg);
                 msg.writer().writeInt(player.nPoint.tlGiap);
                 msg.writer().writeInt(player.nPoint.tlSDCM);
@@ -1116,7 +1116,7 @@ public class Service {
         return 19;
     }
 
-    public void hsChar(Player pl, int hp, int mp) {
+    public void hsChar(Player pl, long hp, long mp) {
         Message msg;
         try {
             if (pl.isPl() && pl.effectSkill != null && pl.effectSkill.isBodyChangeTechnique) {
@@ -1627,7 +1627,7 @@ public class Service {
                 msg.writer().writeShort(pl.pet.nPoint.stamina); //stamina
                 msg.writer().writeShort(pl.pet.nPoint.maxStamina); //stamina full
                 msg.writer().writeByte(pl.pet.nPoint.crit); //crit
-                msg.writer().writeShort(pl.pet.nPoint.def); //def               
+                msg.writer().writeShort((short) pl.pet.nPoint.def); //def               
                 int sizeSkill = pl.pet.playerSkill.skills.size();
                 byte countSkill = 4;
                 if (pl.pet.typePet == 2 || pl.pet.typePet == 3 || pl.pet.typePet == 4) {
@@ -2579,8 +2579,8 @@ public class Service {
             msg.writer().writeByte(pl.gender);
             msg.writer().writeShort(plHead);
             msg.writer().writeUTF(plName);
-            msg.writer().writeInt(pl.nPoint.hp);
-            msg.writer().writeInt(pl.nPoint.hpMax);
+            msg.writer().writeInt((int) pl.nPoint.hp);
+            msg.writer().writeInt((int) pl.nPoint.hpMax);
             msg.writer().writeShort(plBody);
             msg.writer().writeShort(plLeg);
             int flagbag = pl.getFlagBag();

--- a/Source By Mr Blue/src/nro/models/services/SkillService.java
+++ b/Source By Mr Blue/src/nro/models/services/SkillService.java
@@ -403,11 +403,11 @@ public class SkillService {
         }
         switch (player.playerSkill.skillSelect.template.id) {
             case Skill.KAIOKEN:
-                int hpUse = player.nPoint.hpMax / 100 * 10;
+                int hpUse = (int) (player.nPoint.hpMax / 100 * 10);
                 if (player.setClothes.thanVuTruKaio == 4) {
-                    hpUse = player.nPoint.hpMax / 100 * 5;
+                    hpUse = (int) (player.nPoint.hpMax / 100 * 5);
                 } else if (player.setClothes.thanVuTruKaio == 5) {
-                    hpUse = player.nPoint.hpMax / 100 * 3;
+                    hpUse = (int) (player.nPoint.hpMax / 100 * 3);
                 }
                 if (player.nPoint.hp <= hpUse) {
                     break;
@@ -859,19 +859,19 @@ public class SkillService {
                     msg = new Message(56);
                     msg.writer().writeInt((int) plAtt.id);
                     if (damePST >= plAtt.nPoint.hp) {
-                        damePST = plAtt.nPoint.hp - 1;
+                        damePST = (int) (plAtt.nPoint.hp - 1);
                     }
                     if (plAtt.isBoss && !(plAtt instanceof Broly || plAtt instanceof SuperBroly)) {
                         if (damePST > plAtt.nPoint.hpMax / 100) {
                             int giamdame = 0;
                             if (plAtt.nPoint.hpMax / 200 > 1) {
-                                giamdame = Util.nextInt(plAtt.nPoint.hpMax / 200);
+                                giamdame = Util.nextInt((int) (plAtt.nPoint.hpMax / 200));
                             }
-                            damePST = plAtt.nPoint.hpMax / 100 - giamdame;
+                            damePST = (int) (plAtt.nPoint.hpMax / 100 - giamdame);
                         }
                     }
                     damePST = plAtt.injured(plAtt, damePST, true, false);
-                    msg.writer().writeInt(plAtt.nPoint.hp);
+                    msg.writer().writeInt((int) plAtt.nPoint.hp);
                     msg.writer().writeInt(damePST);
                     msg.writer().writeBoolean(false);
                     msg.writer().writeByte(36);
@@ -928,7 +928,7 @@ public class SkillService {
         hutHPMP(plAtt, dameHit, plInjure, null);
         if (plInjure instanceof Yardart) {
             if (plInjure.nPoint.hp < dameHit) {
-                dameHit = plInjure.nPoint.hp - 1;
+                dameHit = (int) (plInjure.nPoint.hp - 1);
                 if (dameHit == 0) {
                     return;
                 }
@@ -1063,7 +1063,7 @@ public class SkillService {
                     return player.nPoint.mp >= skill.manaUse;
                 }
                 case 1 -> {
-                    int mpUse = player.nPoint.mpMax * skill.manaUse / 100;
+                    int mpUse = (int) (player.nPoint.mpMax * skill.manaUse / 100);
                     return player.nPoint.mp >= mpUse;
                 }
                 case 2 -> {


### PR DESCRIPTION
Update game server files to correctly handle `long` values for HP, MP, and damage, resolving type conversion errors.

This PR addresses the "incompatible types: possible lossy conversion from long to int" errors that arose after migrating the core damage calculation from `int` to `long`. Changes include updating method signatures, casting `long` values to `int` or `short` when writing to messages or assigning to `int` variables, and adjusting variable types where necessary.

---
<a href="https://cursor.com/background-agent?bcId=bc-4f960783-415e-46fc-9d13-afdca8e18a09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4f960783-415e-46fc-9d13-afdca8e18a09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

