### PR TITLE
Greet user in vietnamese

### DIFF
--- a/Source By Mr Blue/src/nro/models/Bot/BotAttackplayer.java
+++ b/Source By Mr Blue/src/nro/models/Bot/BotAttackplayer.java
@@ -152,7 +152,7 @@ public class BotAttackplayer extends Bot {
         }
 
         boolean isMiss = false;
-        int realDame = targetPlayer.injured(this, isMiss ? 0 : damage, false, false);
+        long realDame = targetPlayer.injured(this, isMiss ? 0 : damage, false, false);
 
         Skill skill = playerSkill.skillSelect;
 
@@ -164,7 +164,7 @@ public class BotAttackplayer extends Bot {
             msg.writer().writeInt((int) targetPlayer.id);
             msg.writer().writeByte(1);
             msg.writer().writeByte(0);
-            msg.writer().writeInt(realDame);
+            msg.writer().writeLong(realDame);  // Dùng long cho damage cao
             msg.writer().writeBoolean(targetPlayer.isDie());
             msg.writer().writeBoolean(nPoint.isCrit);
             Service.gI().sendMessAllPlayerInMap(this, msg);

--- a/Source By Mr Blue/src/nro/models/map/phoban/BanDoKhoBau.java
+++ b/Source By Mr Blue/src/nro/models/map/phoban/BanDoKhoBau.java
@@ -169,22 +169,22 @@ public class BanDoKhoBau implements Runnable {
                     Mob mob = mobs.get(i);
                     if (((i == 5 || i == 10) && zone.map.mapId == 135) || (i == 5 && zone.map.mapId == 136) || (i == 5 && zone.map.mapId == 137)) {
                         mob.lvMob = 1;
-                        mob.point.dame = (int) Math.min((long) level * 600 * mob.tempId * 10, 2_147_483_647);
-                        mob.point.maxHp = (int) Math.min((long) level * 469799 * mob.tempId, 2_147_483_647);
+                        mob.point.dame = (long) level * 600 * mob.tempId * 10;  // Không giới hạn dame
+                        mob.point.maxHp = (int) Math.min((long) level * 469799 * mob.tempId, Integer.MAX_VALUE);
                         mob.hoiSinh();
                         mob.hoiSinhMobPhoBan();
                     } else {
                         mob.lvMob = 0;
-                        mob.point.dame = (int) Math.min((long) level * 200 * mob.tempId, 2_147_483_647);
-                        mob.point.maxHp = (int) Math.min((long) level * 469799 * mob.tempId, 2_147_483_647);
+                        mob.point.dame = (long) level * 200 * mob.tempId;  // Không giới hạn dame
+                        mob.point.maxHp = (int) Math.min((long) level * 469799 * mob.tempId, Integer.MAX_VALUE);
                         mob.hoiSinh();
                         mob.hoiSinhMobPhoBan();
                     }
                 }
             } else {
                 for (Mob mob : zone.mobs) {
-                    mob.point.dame = (int) Math.min((long) level * 31 * 50 * mob.tempId, 2_147_483_647);
-                    mob.point.maxHp = (int) Math.min((long) level * 310799 * 50 * mob.tempId, 2_147_483_647);
+                    mob.point.dame = (long) level * 31 * 50 * mob.tempId;  // Không giới hạn dame
+                    mob.point.maxHp = (int) Math.min((long) level * 310799 * 50 * mob.tempId, Integer.MAX_VALUE);
                     mob.hoiSinh();
                     mob.hoiSinhMobPhoBan();
                 }

--- a/Source By Mr Blue/src/nro/models/map/phoban/DestronGas.java
+++ b/Source By Mr Blue/src/nro/models/map/phoban/DestronGas.java
@@ -179,14 +179,14 @@ public class DestronGas implements Runnable {
                         ((i == 33) && zone.map.mapId == 152)) { // Quái 76 xuất hiện thứ 34 ở Map 152 (Vùng đất băng giá)
 
                     mob.lvMob = 1;
-                    mob.point.dame = (int) Math.min((long) level * 31 * 5 * mob.tempId * 10, 2_147_483_647);
-                    mob.point.maxHp = (int) Math.min((long) level * 3 * 6700 * mob.tempId * 10, 2_147_483_647);
+                    mob.point.dame = (long) level * 31 * 5 * mob.tempId * 10;  // Không giới hạn dame
+                    mob.point.maxHp = (int) Math.min((long) level * 3 * 6700 * mob.tempId * 10, Integer.MAX_VALUE);
                     mob.hoiSinh();
                     mob.hoiSinhMobPhoBan();
                 } else {
                     mob.lvMob = mob.tempId == 76 ? 1 : 0;
-                    mob.point.dame = (int) Math.min((long) level * 31 * 5 * mob.tempId, 2_147_483_647);
-                    mob.point.maxHp = (int) Math.min((long) level * 5 * 45 * mob.tempId, 2_147_483_647);
+                    mob.point.dame = (long) level * 31 * 5 * mob.tempId;  // Không giới hạn dame
+                    mob.point.maxHp = (int) Math.min((long) level * 5 * 45 * mob.tempId, Integer.MAX_VALUE);
                     mob.hoiSinh();
                     mob.hoiSinhMobPhoBan();
                 }

--- a/Source By Mr Blue/src/nro/models/map/phoban/RedRibbonHQ.java
+++ b/Source By Mr Blue/src/nro/models/map/phoban/RedRibbonHQ.java
@@ -130,8 +130,8 @@ public class RedRibbonHQ implements Runnable {
         for (Zone zone : this.zones) {
             for (Mob mob : zone.mobs) {
                 long mobTempId = mob.tempId;
-                mob.point.dame = (int) ((mobTempId != 0) ? Math.min(totalHp / mobTempId, 2_147_483_647L) : 0);
-                mob.point.maxHp = (int) ((mobTempId != 0) ? Math.min(totalDamage * mobTempId, 2_147_483_647) : 0);
+                mob.point.dame = (mobTempId != 0) ? (totalHp / mobTempId) : 0;  // Không giới hạn dame
+                mob.point.maxHp = (int) ((mobTempId != 0) ? Math.min(totalDamage * mobTempId, Integer.MAX_VALUE) : 0);
                 mob.lvMob = 0;
                 mob.hoiSinh();
                 mob.hoiSinhMobPhoBan();
@@ -143,7 +143,7 @@ public class RedRibbonHQ implements Runnable {
             if (zone.map.mapId == 59) {
                 try {
                     long bossDamage = Math.min(dame, 200_000_000L);
-                    long bossMaxHealth = Math.min(hp, 2_147_483_647L);
+                    long bossMaxHealth = Math.min(hp, Integer.MAX_VALUE);
                     bosses.add(new TrungUyTrang(
                             zone,
                             (int) bossDamage,
@@ -155,7 +155,7 @@ public class RedRibbonHQ implements Runnable {
             if (zone.map.mapId == 62) {
                 try {
                     long bossDamage = Math.min((long) (dame * 1.1), 200_000_000L);
-                    long bossMaxHealth = Math.min((long) (hp * 1.1), 2_147_483_647);
+                    long bossMaxHealth = Math.min((long) (hp * 1.1), Integer.MAX_VALUE);
                     bosses.add(new TrungUyXanhLo(
                             zone,
                             (int) bossDamage,
@@ -167,7 +167,7 @@ public class RedRibbonHQ implements Runnable {
             if (zone.map.mapId == 55) {
                 try {
                     long bossDamage = Math.min((long) (dame * 1.15), 200_000_000L);
-                    long bossMaxHealth = Math.min((long) (hp * 1.15), 2_147_483_647L);
+                    long bossMaxHealth = Math.min((long) (hp * 1.15), Integer.MAX_VALUE);
                     bosses.add(new TrungUyThep(
                             zone,
                             (int) bossDamage,
@@ -179,7 +179,7 @@ public class RedRibbonHQ implements Runnable {
             if (zone.map.mapId == 54) {
                 try {
                     long bossDamage = Math.min((long) (dame * 1.2), 200_000_000L);
-                    long bossMaxHealth = Math.min((long) (hp * 1.2), 2_147_483_647);
+                    long bossMaxHealth = Math.min((long) (hp * 1.2), Integer.MAX_VALUE);
                     bosses.add(new NinjaAoTim(
                             zone,
                             clan,
@@ -193,7 +193,7 @@ public class RedRibbonHQ implements Runnable {
             if (zone.map.mapId == 57) {
                 try {
                     long bossDamage = Math.min((long) (dame * 1.3), 200_000_000L);
-                    long bossMaxHealth = Math.min((long) (hp * 1.3), 2_147_483_647);
+                    long bossMaxHealth = Math.min((long) (hp * 1.3), Integer.MAX_VALUE);
                     for (int i = 0; i < 4; i++) {
                         bosses.add(new RobotVeSi(
                                 zone,
@@ -327,8 +327,8 @@ public class RedRibbonHQ implements Runnable {
                 if (mob.isDie()) {
                     continue;
                 }
-                mob.point.dame = (int) (totalHp / mob.tempId < 2_147_483_647 ? totalHp / mob.tempId : 2_147_483_647);
-                mob.point.maxHp = (int) (totalDame/3 * mob.tempId < 2_147_483_647 ? totalDame * mob.tempId : 2_147_483_647);
+                mob.point.dame = totalHp / mob.tempId;  // Không giới hạn dame
+                mob.point.maxHp = (int) Math.min(totalDame * mob.tempId, Integer.MAX_VALUE);
                 mob.point.hp = mob.point.maxHp;
                 mob.setTiemNang();
             }

--- a/Source By Mr Blue/src/nro/models/mob/Mob.java
+++ b/Source By Mr Blue/src/nro/models/mob/Mob.java
@@ -178,9 +178,7 @@ public class Mob {
                 lastTimeAttackPlayer = System.currentTimeMillis();
             }
 
-            if (damage > 2_147_483_647) {
-                damage = 2_147_483_647;
-            }
+            // Bỏ giới hạn damage để hỗ trợ damage cao
 
             this.point.hp -= damage;
             addTemporaryEnemies(plAtt);
@@ -189,7 +187,7 @@ public class Mob {
                 this.setDie();
                 this.temporaryEnemies.clear();
                 if (plAtt != null) {
-                    this.sendMobDieAffterAttacked(plAtt, (int) damage);
+                    this.sendMobDieAffterAttacked(plAtt, damage);
                     TaskService.gI().checkDoneTaskKillMob(plAtt, this);
                     TaskService.gI().checkDoneSideTaskKillMob(plAtt, this);
                     TaskService.gI().checkDoneClanTaskKillMob(plAtt, this);
@@ -202,7 +200,7 @@ public class Mob {
                     this.zone.isbulon2Alive = false;
                 }
             } else {
-                this.sendMobStillAliveAffterAttacked((int) damage, plAtt != null ? (plAtt.nPoint != null && plAtt.nPoint.isCrit) : false);
+                this.sendMobStillAliveAffterAttacked(damage, plAtt != null ? (plAtt.nPoint != null && plAtt.nPoint.isCrit) : false);
             }
             if (plAtt != null) {
                 if (plAtt.isPl() && plAtt.satellite != null && plAtt.satellite.isDefend) {
@@ -403,7 +401,7 @@ public class Mob {
             return;
         }
 
-        int dameMob = this.point.getDameAttack();
+        long dameMob = this.point.getDameAttack();
 
         if (player.charms != null && player.charms.tdDaTrau > System.currentTimeMillis()) {
             dameMob /= 2;
@@ -431,19 +429,19 @@ public class Mob {
         if (this.lvMob > 0 && player.charms != null && player.charms.tdOaiHung > System.currentTimeMillis()) {
         }
 
-        int dame = player.injured(null, dameMob, false, true);
+        long dame = player.injured(null, dameMob, false, true);
         this.sendMobAttackMe(player, dame);
         this.sendMobAttackPlayer(player);
         this.phanSatThuong(player, dame);
     }
 
-    private void sendMobAttackMe(Player player, int dame) {
+    private void sendMobAttackMe(Player player, long dame) {
         if (!player.isPet && !player.isBot && !player.isNewPet) {
             Message msg;
             try {
                 msg = new Message(-11);
                 msg.writer().writeByte(this.id);
-                msg.writer().writeInt(dame);
+                msg.writer().writeLong(dame);  // Dùng long
                 player.sendMessage(msg);
                 msg.cleanup();
             } catch (Exception e) {
@@ -571,12 +569,12 @@ public class Mob {
         }
     }
 
-    private void sendMobDieAffterAttacked(Player plKill, int dameHit) {
+    private void sendMobDieAffterAttacked(Player plKill, long dameHit) {
         Message msg;
         try {
             msg = new Message(-12);
             msg.writer().writeByte(this.id);
-            msg.writer().writeInt(dameHit);
+            msg.writer().writeLong(dameHit);  // Dùng long để support damage cao
             msg.writer().writeBoolean(plKill.nPoint.isCrit);
             List<ItemMap> items = mobReward(plKill, this.dropItemTask(plKill), msg);
             Service.gI().sendMessAllPlayerInMap(this.zone, msg);
@@ -633,13 +631,13 @@ public class Mob {
         return itemReward;
     }
 
-    private void sendMobStillAliveAffterAttacked(int dameHit, boolean crit) {
+    private void sendMobStillAliveAffterAttacked(long dameHit, boolean crit) {
         Message msg;
         try {
             msg = new Message(-9);
             msg.writer().writeByte(this.id);
             msg.writer().writeInt(this.point.gethp());
-            msg.writer().writeInt(dameHit);
+            msg.writer().writeLong(dameHit);  // Dùng long để support damage cao
             msg.writer().writeBoolean(crit); // chí mạng
             msg.writer().writeInt(-1);
             Service.gI().sendMessAllPlayerInMap(this.zone, msg);

--- a/Source By Mr Blue/src/nro/models/mob/MobMe.java
+++ b/Source By Mr Blue/src/nro/models/mob/MobMe.java
@@ -18,8 +18,8 @@ public final class MobMe extends Mob {
         this.id = (int) player.id;
         int level = player.playerSkill.getSkillbyId(12).point;
         this.tempId = SkillUtil.getTempMobMe(level);
-        this.point.maxHp = (int) Math.min(SkillUtil.getHPMobMe(player.nPoint.hpMax, level), 2_147_483_647);
-        this.point.dame = (int) Math.min(SkillUtil.getHPMobMe(player.nPoint.getDameAttack(false), level), 2_147_483_647);
+        this.point.maxHp = (int) Math.min(SkillUtil.getHPMobMe(player.nPoint.hpMax, level), Integer.MAX_VALUE);
+        this.point.dame = SkillUtil.getHPMobMe(player.nPoint.getDameAttack(false), level);  // Không giới hạn dame
         this.point.hp = this.point.maxHp;
         this.zone = player.zone;
         this.lastTimeSpawn = System.currentTimeMillis();
@@ -39,14 +39,14 @@ public final class MobMe extends Mob {
         Message msg;
         try {
             if (pl != null) {
-                int dame = !miss ? this.point.dame : 0;
+                long dame = !miss ? this.point.dame : 0;
                 if ((pl.nPoint.hp > dame && pl.nPoint.hp > pl.nPoint.hpMax * 0.05) || this.player.setClothes.pikkoroDaimao == 5) {
-                    int dameHit = pl.injured(this.player, dame, true, true);
+                    long dameHit = pl.injured(this.player, dame, true, true);
                     msg = new Message(-95);
                     msg.writer().writeByte(2);
                     msg.writer().writeInt(this.id);
                     msg.writer().writeInt((int) pl.id);
-                    msg.writer().writeInt(dameHit);
+                    msg.writer().writeLong(dameHit);  // Dùng long cho damage cao
                     msg.writer().writeInt(pl.nPoint.hp);
                     Service.gI().sendMessAllPlayerInMap(this.player, msg);
                     msg.cleanup();

--- a/Source By Mr Blue/src/nro/models/mob/MobPoint.java
+++ b/Source By Mr Blue/src/nro/models/mob/MobPoint.java
@@ -7,7 +7,7 @@ public class MobPoint {
     public final Mob mob;
     public int hp;
     public int maxHp;
-    public int dame;
+    public long dame;  // Đổi sang long để support damage cao
 
     public MobPoint(Mob mob) {
         this.mob = mob;
@@ -33,8 +33,8 @@ public class MobPoint {
         }
     }
 
-    public int getDameAttack() {
-        return this.dame != 0 ? this.dame + Util.nextInt(-(this.dame / 100), (this.dame / 100))
+    public long getDameAttack() {
+        return this.dame != 0 ? this.dame + Util.nextInt(-(int)(this.dame / 100), (int)(this.dame / 100))
                 : this.getHpFull() * Util.nextInt(mob.pDame - 1, mob.pDame + 1) / 100
                 + Util.nextInt(-(mob.level * 10), mob.level * 10);
     }

--- a/Source By Mr Blue/src/nro/models/mob_bigboss/GaChinCua.java
+++ b/Source By Mr Blue/src/nro/models/mob_bigboss/GaChinCua.java
@@ -69,9 +69,9 @@ public class GaChinCua extends BigBoss {
                         msg.writer().writeByte(players.size()); // sl player;
                         int dir = 0;
                         for (Player pl : players) {
-                            int dame = pl.injured(null, this.point.getDameAttack(), false, true);
+                            long dame = pl.injured(null, this.point.getDameAttack(), false, true);
                             msg.writer().writeInt((int) pl.id); // id player
-                            msg.writer().writeInt(dame); // dame
+                            msg.writer().writeLong(dame); // dame - dùng long
                             dir = pl.location.x < this.location.x ? -1 : 1;
                         }
                         msg.writer().writeByte(dir); // dir

--- a/Source By Mr Blue/src/nro/models/mob_bigboss/GauTuongCuop.java
+++ b/Source By Mr Blue/src/nro/models/mob_bigboss/GauTuongCuop.java
@@ -74,9 +74,9 @@ public class GauTuongCuop extends Mob {
                     msg.writer().writeByte(targets.size());
                     int dir = 0;
                     for (Player pl : targets) {
-                        int dame = pl.injured(null, this.getDameAttack(), false, true);
+                        long dame = pl.injured(null, this.getDameAttack(), false, true);
                         msg.writer().writeInt((int) pl.id);
-                        msg.writer().writeInt(dame);
+                        msg.writer().writeLong(dame);  // Dùng long
                         dir = pl.location.x < this.location.x ? -1 : 1;
                     }
                     msg.writer().writeByte(dir);

--- a/Source By Mr Blue/src/nro/models/mob_bigboss/Hirudegarn.java
+++ b/Source By Mr Blue/src/nro/models/mob_bigboss/Hirudegarn.java
@@ -189,9 +189,9 @@ public class Hirudegarn extends BigBoss {
                     switch (action) {
                         case 1:
                             msg.writer().writeByte(1);
-                            int dame = player.injured(null, this.point.getDameAttack(), false, true);
+                            long dame = player.injured(null, this.point.getDameAttack(), false, true);
                             msg.writer().writeInt((int) player.id);
-                            msg.writer().writeInt(dame);
+                            msg.writer().writeLong(dame);  // Dùng long
                             break;
                         case 3:
                             this.location.x = (short) player.location.x;

--- a/Source By Mr Blue/src/nro/models/mob_bigboss/NguaChinLmao.java
+++ b/Source By Mr Blue/src/nro/models/mob_bigboss/NguaChinLmao.java
@@ -69,9 +69,9 @@ public class NguaChinLmao extends BigBoss {
                         msg.writer().writeByte(players.size()); // sl player;
                         int dir = 0;
                         for (Player pl : players) {
-                            int dame = pl.injured(null, this.point.getDameAttack(), false, true);
+                            long dame = pl.injured(null, this.point.getDameAttack(), false, true);
                             msg.writer().writeInt((int) pl.id); // id player
-                            msg.writer().writeInt(dame); // dame
+                            msg.writer().writeLong(dame); // dame - dùng long
                             dir = pl.location.x < this.location.x ? -1 : 1;
                         }
                         msg.writer().writeByte(dir); // dir

--- a/Source By Mr Blue/src/nro/models/mob_bigboss/Piano.java
+++ b/Source By Mr Blue/src/nro/models/mob_bigboss/Piano.java
@@ -77,9 +77,9 @@ public class Piano extends BigBoss {
                         msg.writer().writeByte(players.size()); // sl player;
                         int dir = 0;
                         for (Player pl : players) {
-                            int dame = pl.injured(null, this.point.getDameAttack(), false, true);
+                            long dame = pl.injured(null, this.point.getDameAttack(), false, true);
                             msg.writer().writeInt((int) pl.id); // id player
-                            msg.writer().writeInt(dame); // dame
+                            msg.writer().writeLong(dame); // dame - dùng long
                             dir = pl.location.x < this.location.x ? -1 : 1;
                         }
                         msg.writer().writeByte(dir); // dir

--- a/Source By Mr Blue/src/nro/models/mob_bigboss/RobotBaoVe.java
+++ b/Source By Mr Blue/src/nro/models/mob_bigboss/RobotBaoVe.java
@@ -24,8 +24,8 @@ public class RobotBaoVe extends BigBoss {
         Player player = getPlayerCanAttack();
         if (!isDie() && !effectSkill.isHaveEffectSkill() && Util.canDoWithTime(lastBigBossAttackTime, 1000)) {
             if (player != null) {
-                int dameMob = this.point.getDameAttack();
-                int dame = player.injured(null, dameMob, false, true);
+                long dameMob = this.point.getDameAttack();
+                long dame = player.injured(null, dameMob, false, true);
                 action = 0;
                 int dis = Util.getDistance(player, this);
                 if (dis <= 100) {

--- a/Source By Mr Blue/src/nro/models/mob_bigboss/VoiChinNga.java
+++ b/Source By Mr Blue/src/nro/models/mob_bigboss/VoiChinNga.java
@@ -69,9 +69,9 @@ public class VoiChinNga extends BigBoss {
                         msg.writer().writeByte(players.size()); // sl player;
                         int dir = 0;
                         for (Player pl : players) {
-                            int dame = pl.injured(null, this.point.getDameAttack(), false, true);
+                            long dame = pl.injured(null, this.point.getDameAttack(), false, true);
                             msg.writer().writeInt((int) pl.id); // id player
-                            msg.writer().writeInt(dame); // dame
+                            msg.writer().writeLong(dame); // dame - dùng long
                             dir = pl.location.x < this.location.x ? -1 : 1;
                         }
                         msg.writer().writeByte(dir); // dir

--- a/Source By Mr Blue/src/nro/models/mob_bigboss/VuaBachTuoc.java
+++ b/Source By Mr Blue/src/nro/models/mob_bigboss/VuaBachTuoc.java
@@ -25,8 +25,8 @@ public class VuaBachTuoc extends BigBoss {
         Player player = getPlayerCanAttack();
         if (!isDie() && !effectSkill.isHaveEffectSkill() && Util.canDoWithTime(lastBigBossAttackTime, 1000)) {
             if (player != null && player.location.x > 440 && player.location.x < 950) {
-                int dameMob = this.point.getDameAttack();
-                int dame = player.injured(null, dameMob, false, true);
+                long dameMob = this.point.getDameAttack();
+                long dame = player.injured(null, dameMob, false, true);
                 action = 3;
                 int dis = Util.getDistance(player, this);
                 if (dis <= 100) {

--- a/Source By Mr Blue/src/nro/models/player/NPoint.java
+++ b/Source By Mr Blue/src/nro/models/player/NPoint.java
@@ -54,7 +54,7 @@ public class NPoint {
 
     private Intrinsic intrinsic;
     private int percentDameIntrinsic;
-    public int dameAfter;
+    public long dameAfter;  // Đổi sang long để damage vượt 2 tỷ
 
     /*-----------------------Chỉ số cơ bản------------------------------------*/
     public byte numAttack;
@@ -66,7 +66,7 @@ public class NPoint {
 
     public int hp, hpMax, hpg;
     public int mp, mpMax, mpg;
-    public int dame, dameg;
+    public long dame, dameg;  // Đổi sang long để damage vượt 2 tỷ
     public int def, defg;
     public int crit, critg, critdragon;
     public int GiamST;
@@ -80,7 +80,8 @@ public class NPoint {
     /**
      * Chỉ số cộng thêm
      */
-    public int hpAdd, mpAdd, dameAdd, defAdd, critAdd, hpHoiAdd, mpHoiAdd;
+    public int hpAdd, mpAdd, defAdd, critAdd, hpHoiAdd, mpHoiAdd;
+    public long dameAdd;  // Đổi sang long để damage vượt 2 tỷ
 
     /**
      * //+#% sức đánh chí mạng
@@ -1207,8 +1208,9 @@ public class NPoint {
             dame /= 2;
         }
 
-        if (dame > 2_147_483_647) {
-            dame = 2_147_483_647;
+        // Giới hạn damage tối đa: 999 nghìn tỷ (đủ cho game Trung Quốc)
+        if (dame > 999_000_000_000_000L) {
+            dame = 999_000_000_000_000L;
         }
 
         if (this.player.setClothes.ThanHuyDietChampa == 2) {
@@ -1379,9 +1381,9 @@ public class NPoint {
         }
     }
 
-    public int getDameAttack(boolean isAttackMob) {
+    public long getDameAttack(boolean isAttackMob) {
         setIsCrit();
-        int dameAttack = this.dame;
+        long dameAttack = this.dame;
         intrinsic = this.player.playerIntrinsic.intrinsic;
         percentDameIntrinsic = 0;
         int percentDameSkill = 0;
@@ -1476,12 +1478,12 @@ case Skill.MA_PHONG_BA:             // Ma Phong Ba (Namec)
             case Skill.DICH_CHUYEN_TUC_THOI:
                 isCrit = true;
                 isCritTele = true;
-                dameAttack = Util.nextInt((int) (int) Math.min(2_147_483_647L, (dameAttack - (dameAttack / 100 * 5))),
-                        (int) (int) Math.min(2_147_483_647L, (dameAttack + (dameAttack / 100 * 5))));
+                dameAttack = Util.nextInt((int) (dameAttack - (dameAttack / 100 * 5)),
+                        (int) (dameAttack + (dameAttack / 100 * 5)));
                 break;
             case Skill.MAKANKOSAPPO:
                 percentDameSkill = skillSelect.damage;
-                int dameSkill = (int) Math.min(2_147_483_647L, (long) this.mpMax * percentDameSkill / 100);
+                long dameSkill = (long) this.mpMax * percentDameSkill / 100;
                 if (this.player.setClothes.picolo == 5) {
                     dameSkill *= 3 / 2;
                 }
@@ -1510,18 +1512,14 @@ case Skill.MA_PHONG_BA:             // Ma Phong Ba (Namec)
                 }
 
                 dameqckk = dameqckk + (Util.nextInt(-5, 5) * dameqckk / 100);
-                if (dameqckk > 2_147_483_647) {
-                    dameqckk = 2_147_483_647;
-                }
-                return (int) dameqckk;
+                // Không giới hạn damage nữa, để lên cao
+                return dameqckk;
             case Skill.DE_TRUNG:
                 if (player.setClothes.pikkoroDaimao == 5) {
                     dameAttack *= 4;
                 }
-                if (dameAttack > 2_147_483_647) {
-                    dameAttack = 2_147_483_647;
-                }
-                return (int) dameAttack;
+                // Không giới hạn damage nữa
+                return dameAttack;
         }
 
         if (intrinsic.id == 18 && this.player.effectSkill.isMonkey) {
@@ -1574,11 +1572,11 @@ case Skill.MA_PHONG_BA:             // Ma Phong Ba (Namec)
             player.effectSkin.lastTimeXChuong = System.currentTimeMillis();
         }
 
-        if (dameAttack
-                > 2_147_483_647) {
-            dameAttack = 2_147_483_647;
+        // Giới hạn damage tối đa 999 nghìn tỷ
+        if (dameAttack > 999_000_000_000_000L) {
+            dameAttack = 999_000_000_000_000L;
         }
-        return (int) dameAttack;
+        return dameAttack;
     }
 
     public int getCurrPercentHP() {

--- a/Source By Mr Blue/src/nro/models/player/Player.java
+++ b/Source By Mr Blue/src/nro/models/player/Player.java
@@ -360,7 +360,7 @@ public class Player implements Runnable {
     public int wearingBackItemId = 78;
     public long lastClickTimeOption7;
     public transient List<String> currentNpcMenuOptions;
-    public int lastDamage;
+    public long lastDamage;  // Đổi sang long để lưu damage cao
     public long lastCaptchaTime = 0;
     public boolean requireCaptcha = false;
     public String captchaAnswer = "";
@@ -1055,7 +1055,7 @@ public class Player implements Runnable {
         }
     }
 
-    public synchronized int injured(Player plAtt, long damage, boolean piercing, boolean isMobAttack) {
+    public synchronized long injured(Player plAtt, long damage, boolean piercing, boolean isMobAttack) {
         if (!this.isDie()) {
             if (plAtt != null && !plAtt.equals(this)) {
                 setTemporaryEnemies(plAtt);
@@ -1182,7 +1182,7 @@ public class Player implements Runnable {
 
             if (!piercing && effectSkill.isShielding && !isMobAttack) {
                 if (this.idMark != null) {
-                    this.idMark.setDamePST((int) Math.min(damage, 2_147_483_647L));
+                    this.idMark.setDamePST((int) Math.min(damage, Integer.MAX_VALUE));
                 }
                 if (damage > nPoint.hpMax) {
                     EffectSkillService.gI().breakShield(this);
@@ -1192,7 +1192,7 @@ public class Player implements Runnable {
                     damage = 10;
                 }
             }
-            damage = Math.min(damage, 2_147_483_647);
+            // Bỏ giới hạn damage để có thể đạt 5-50 tỷ
             if (isMobAttack && this.charms.tdBatTu > System.currentTimeMillis() && damage >= this.nPoint.hp) {
                 damage = this.nPoint.hp - 1;
             }
@@ -1225,7 +1225,7 @@ public class Player implements Runnable {
                 }
             }
 
-            return (int) damage;
+            return damage;  // Trả về long để support damage cao
         } else {
             return 0;
         }

--- a/Source By Mr Blue/src/nro/models/services/Service.java
+++ b/Source By Mr Blue/src/nro/models/services/Service.java
@@ -2458,8 +2458,8 @@ public class Service {
             msg.writer().writeByte(player.zone.getNotBosses().size()); // số player
             for (Player plM : player.zone.getNotBosses()) {
                 msg.writer().writeInt((int) plM.id);
-                int damage = plM.injured(player, player.nPoint.dame + plM.nPoint.hp / 10, true, false);
-                msg.writer().writeInt(damage);
+                long damage = plM.injured(player, player.nPoint.dame + plM.nPoint.hp / 10, true, false);
+                msg.writer().writeLong(damage);  // Dùng long cho damage cao
             }
             sendMessAllPlayerInMap(player, msg);
             msg.cleanup();

--- a/Source By Mr Blue/src/nro/models/services/SkillService.java
+++ b/Source By Mr Blue/src/nro/models/services/SkillService.java
@@ -918,12 +918,12 @@ public class SkillService {
                 dameAttack /= 3;
             }
         }
-        int dameHit = plInjure.injured(plAtt, miss ? 0 : dameAttack, false, false);
+        long dameHit = plInjure.injured(plAtt, miss ? 0 : dameAttack, false, false);
         if (plAtt.playerSkill == null) {
             return;
         }
         Skill skillSelect = plAtt.playerSkill.skillSelect;
-        int damePST = plInjure.effectSkill != null && plInjure.effectSkill.isShielding && plInjure.idMark != null ? plInjure.idMark.getDamePST() : dameHit;
+        long damePST = plInjure.effectSkill != null && plInjure.effectSkill.isShielding && plInjure.idMark != null ? plInjure.idMark.getDamePST() : dameHit;
         phanSatThuong(plAtt, plInjure, miss ? 0 : damePST);
         hutHPMP(plAtt, dameHit, plInjure, null);
         if (plInjure instanceof Yardart) {
@@ -945,7 +945,7 @@ public class SkillService {
             msg.writer().writeInt((int) plInjure.id); //id ăn pem
             msg.writer().writeByte(1); //read continue
             msg.writer().writeByte(0); //type skill
-            msg.writer().writeInt(dameHit); //dame ăn
+            msg.writer().writeLong(dameHit); //dame ăn - dùng long để support damage cao
             msg.writer().writeBoolean(plInjure.isDie()); //is die
             msg.writer().writeBoolean(plAtt.nPoint.isCrit); //crit
             Service.gI().sendMessAllPlayerInMap(plAtt, msg);
@@ -1002,7 +1002,7 @@ public class SkillService {
             dameHit = 0;
         }
 
-        dameHit = Math.min(dameHit, 2_147_483_647);
+        // Bỏ giới hạn damage để có thể đánh 5-50 tỷ
 
         hutHPMP(plAtt, dameHit, null, mob);
         sendPlayerAttackMob(plAtt, mob);

--- a/Source By Mr Blue/src/nro/models/services_dungeon/SuperDivineWaterService.java
+++ b/Source By Mr Blue/src/nro/models/services_dungeon/SuperDivineWaterService.java
@@ -78,16 +78,16 @@ public class SuperDivineWaterService {
         for (Mob mob : zone.mobs) {
             switch (mob.tempId) {
                 case 26:
-                    mob.point.dame = (int) Math.min(totalHp * 150 / 100, 2_147_483_647L);
-                    mob.point.maxHp = (int) Math.min(totalDamage * 150 / 100, 2_147_483_647L);
+                    mob.point.dame = totalHp * 150 / 100;  // Không giới hạn dame
+                    mob.point.maxHp = (int) Math.min(totalDamage * 150 / 100, Integer.MAX_VALUE);
                     break;
                 case 25:
-                    mob.point.dame = (int) Math.min(totalHp * 2, 2_147_483_647L);
-                    mob.point.maxHp = (int) Math.min(totalDamage * 2, 2_147_483_647L);
+                    mob.point.dame = totalHp * 2;  // Không giới hạn dame
+                    mob.point.maxHp = (int) Math.min(totalDamage * 2, Integer.MAX_VALUE);
                     break;
                 default:
-                    mob.point.dame = (int) Math.min(totalHp, 2_147_483_647L);
-                    mob.point.maxHp = (int) Math.min(totalDamage, 2_147_483_647L);
+                    mob.point.dame = totalHp;  // Không giới hạn dame
+                    mob.point.maxHp = (int) Math.min(totalDamage, Integer.MAX_VALUE);
                     break;
             }
             mob.lvMob = 0;
@@ -110,7 +110,7 @@ public class SuperDivineWaterService {
                     if (allCharactersDead) {
                         try {
                             long bossDamage = Math.min((long) (player.nPoint.dame), 200_000_000L);
-                            long bossMaxHealth = Math.min(((long) player.nPoint.hpMax * 5), 2_147_483_647L);
+                            long bossMaxHealth = Math.min(((long) player.nPoint.hpMax * 5), Integer.MAX_VALUE);
                             new Pocolo(
                                     player.zone,
                                     player,


### PR DESCRIPTION
Migrate server-side damage calculations and storage from `int` to `long` to support damage values exceeding 2.1 billion.

This change removes the `int` data type limitation (max ~2.1 billion) on damage values, allowing the game to handle much larger damage numbers (up to 999 trillion). This is necessary for implementing higher damage mechanics similar to "game trung" style servers. **Note:** Client-side (Unity C#) must also be updated to read `long` for damage values to avoid overflow or crashes.

---
<a href="https://cursor.com/background-agent?bcId=bc-976732b8-660a-46e7-98ce-ee66c450c63e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-976732b8-660a-46e7-98ce-ee66c450c63e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

